### PR TITLE
[PPX DEPS] relax ppxlib constraint

### DIFF
--- a/pgocaml_ppx.opam
+++ b/pgocaml_ppx.opam
@@ -20,6 +20,6 @@ depends: [
   "dune" {>= "1.10"}
   "ocaml" {>= "4.07"}
   "pgocaml" {= version}
-  "ppxlib" {>= "0.16.0"}
+  "ppxlib"
   "ppx_optcomp"
 ]

--- a/ppx/compat.1.ml
+++ b/ppx/compat.1.ml
@@ -1,0 +1,3 @@
+let string_literal = function
+  | Ppxlib.Pconst_string (s, _) -> Some s
+  | _ -> None

--- a/ppx/compat.2.ml
+++ b/ppx/compat.2.ml
@@ -1,0 +1,3 @@
+let string_literal = function
+  | Ppxlib.Pconst_string (s, _, _) -> Some s
+  | _ -> None

--- a/ppx/dune
+++ b/ppx/dune
@@ -1,7 +1,23 @@
-(library
-  (name pgocaml_ppx)
-  (public_name pgocaml_ppx)
-  (kind ppx_rewriter)
-  (preprocess (pps ppx_optcomp ppxlib.metaquot))
-  (libraries ppxlib pgocaml)
-  (modules ppx_pgsql))
+(* -*- tuareg -*- *)
+
+let () =
+  let cmd = "ocamlfind query -format %v ppxlib" in
+  let omp = match Jbuild_plugin.V1.run_and_read_lines cmd with
+    | [] | _ :: _ :: _ -> failwith "no ppxlib installed"
+    | [ version ] ->
+      match String.split_on_char '.' version with
+      | [ major; minor; _ ] ->
+        if int_of_string major > 0 then 2
+        else if int_of_string minor > 15 then 2
+        else 1
+      | _ -> failwith ("version " ^ version ^ " not understood") in
+  Printf.kprintf
+    Jbuild_plugin.V1.send
+    "(library
+     (name pgocaml_ppx)
+     (public_name pgocaml_ppx)
+     (kind ppx_rewriter)
+     (preprocess (pps ppx_optcomp ppxlib.metaquot))
+     (libraries ppxlib pgocaml (select compat.ml from (-> compat.%d.ml)))
+     (modules compat ppx_pgsql))"
+    omp

--- a/ppx/ppx_pgsql.ml
+++ b/ppx/ppx_pgsql.ml
@@ -173,11 +173,7 @@ let loc_raise _loc exn =
   raise exn
 
 let const_string ~loc str =
-  { pexp_desc = Pexp_constant (Pconst_string (str, loc, None));
-    pexp_loc = loc;
-    pexp_attributes = [];
-    pexp_loc_stack = []
-  }
+  Ast_builder.Default.estring ~loc str
 
 let parse_flags flags loc =
   let f_execute = ref false in
@@ -684,8 +680,8 @@ let expand_sql ~genobject loc dbh extras =
 let list_of_string_args args =
   let maybe_strs =
     List.map (function
-        | (Nolabel, {pexp_desc = Pexp_constant (Pconst_string (str, _, None)); _})
-          -> Some str
+        | (Nolabel, {pexp_desc = Pexp_constant cst; _})
+          -> Compat.string_literal cst
         | _ -> None) args in
   if List.mem None maybe_strs then []
   else List.map (function Some x -> x | None -> assert false) maybe_strs


### PR DESCRIPTION
Use different compat files to handle the different version of
the parsetree, here the only difference are the string constants.